### PR TITLE
Implement API integration and fix component metadata

### DIFF
--- a/marketplace-frontend/README.md
+++ b/marketplace-frontend/README.md
@@ -38,11 +38,16 @@ This will compile your project and store the build artifacts in the `dist/` dire
 
 ## Running unit tests
 
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
+To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, run:
 
 ```bash
-ng test
+npm test
 ```
+
+## Environment configuration
+
+The base URL for the microservices backend is set in `src/environments/environment.ts`.
+Adjust the `apiUrl` value to match your backend server.
 
 ## Running end-to-end tests
 

--- a/marketplace-frontend/src/app/app.component.ts
+++ b/marketplace-frontend/src/app/app.component.ts
@@ -3,9 +3,10 @@ import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
   imports: [RouterOutlet],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'marketplace-frontend';

--- a/marketplace-frontend/src/app/app.config.ts
+++ b/marketplace-frontend/src/app/app.config.ts
@@ -1,8 +1,15 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { authInterceptor } from './core/interceptors/auth.interceptor';
+import { errorInterceptor } from './core/interceptors/error.interceptor';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideHttpClient(withInterceptors([authInterceptor, errorInterceptor]))
+  ]
 };

--- a/marketplace-frontend/src/app/core/auth/auth.service.spec.ts
+++ b/marketplace-frontend/src/app/core/auth/auth.service.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+import { ApiService } from '../services/api.service';
+import { environment } from '../../../environments/environment';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService, ApiService]
+    });
+    service = TestBed.inject(AuthService);
+    http = TestBed.inject(HttpTestingController);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    http.verify();
+    localStorage.clear();
+  });
+
+  it('should store token on login', () => {
+    service.login({ correo: 'a', contrasena: 'b' }).subscribe();
+    const req = http.expectOne(`${environment.apiUrl}/auth/login`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ token: '123' });
+    expect(localStorage.getItem('access_token')).toBe('123');
+  });
+});

--- a/marketplace-frontend/src/app/core/auth/auth.service.ts
+++ b/marketplace-frontend/src/app/core/auth/auth.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { Observable, tap } from 'rxjs';
+import { ApiService } from '../services/api.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private tokenKey = 'access_token';
+
+  constructor(private api: ApiService) {}
+
+  login(credentials: { correo: string; contrasena: string }): Observable<{ token: string }> {
+    return this.api.post<{ token: string }>('auth/login', credentials).pipe(
+      tap(res => localStorage.setItem(this.tokenKey, res.token))
+    );
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.tokenKey);
+  }
+}

--- a/marketplace-frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/marketplace-frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,12 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from '../auth/auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const auth = inject(AuthService);
+  const token = auth.getToken();
+  if (token) {
+    req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+  }
+  return next(req);
+};

--- a/marketplace-frontend/src/app/core/interceptors/error.interceptor.ts
+++ b/marketplace-frontend/src/app/core/interceptors/error.interceptor.ts
@@ -1,0 +1,11 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { catchError, throwError } from 'rxjs';
+
+export const errorInterceptor: HttpInterceptorFn = (req, next) => {
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      console.error('HTTP Error:', error);
+      return throwError(() => error);
+    })
+  );
+};

--- a/marketplace-frontend/src/app/core/services/api.service.spec.ts
+++ b/marketplace-frontend/src/app/core/services/api.service.spec.ts
@@ -1,0 +1,28 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ApiService } from './api.service';
+import { environment } from '../../../environments/environment';
+
+describe('ApiService', () => {
+  let service: ApiService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ApiService]
+    });
+    service = TestBed.inject(ApiService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should make POST requests with base url', () => {
+    service.post('test', {foo: 'bar'}).subscribe();
+    const req = http.expectOne(`${environment.apiUrl}/test`);
+    expect(req.request.method).toBe('POST');
+  });
+});

--- a/marketplace-frontend/src/app/core/services/api.service.ts
+++ b/marketplace-frontend/src/app/core/services/api.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  private baseUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  get<T>(endpoint: string, options?: object): Observable<T> {
+    return this.http.get<T>(`${this.baseUrl}/${endpoint}`, options);
+  }
+
+  post<T>(endpoint: string, body: unknown, options?: object): Observable<T> {
+    return this.http.post<T>(`${this.baseUrl}/${endpoint}`, body, options);
+  }
+}

--- a/marketplace-frontend/src/app/features/auth/auth.component.spec.ts
+++ b/marketplace-frontend/src/app/features/auth/auth.component.spec.ts
@@ -8,7 +8,7 @@ describe('AuthComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AuthComponent]
+      imports: [AuthComponent]
     })
     .compileComponents();
 

--- a/marketplace-frontend/src/app/features/auth/auth.component.ts
+++ b/marketplace-frontend/src/app/features/auth/auth.component.ts
@@ -2,9 +2,9 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-auth',
-  standalone: false,
+  standalone: true,
   templateUrl: './auth.component.html',
-  styleUrl: './auth.component.scss'
+  styleUrls: ['./auth.component.scss']
 })
 export class AuthComponent {
 

--- a/marketplace-frontend/src/app/features/auth/login/login.component.spec.ts
+++ b/marketplace-frontend/src/app/features/auth/login/login.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LoginComponent } from './login.component';
+import { AuthService } from '../../core/auth/auth.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -8,7 +10,8 @@ describe('LoginComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LoginComponent]
+      imports: [LoginComponent, HttpClientTestingModule],
+      providers: [AuthService]
     })
     .compileComponents();
 

--- a/marketplace-frontend/src/app/features/auth/login/login.component.ts
+++ b/marketplace-frontend/src/app/features/auth/login/login.component.ts
@@ -7,6 +7,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatError } from '@angular/material/form-field'; // solo si da errores
 import { RouterModule } from '@angular/router';
+import { AuthService } from '../../core/auth/auth.service';
 
 
 @Component({
@@ -22,13 +23,13 @@ import { RouterModule } from '@angular/router';
     RouterModule
   ],
   templateUrl: './login.component.html',
-  styleUrl: './login.component.scss'
+  styleUrls: ['./login.component.scss']
 })
 export class LoginComponent {
 
    loginForm: FormGroup;
 
-  constructor(private fb: FormBuilder) {
+  constructor(private fb: FormBuilder, private auth: AuthService) {
     this.loginForm = this.fb.group({
       correo: ['', [Validators.required, Validators.email]],
       contrasena: ['', Validators.required],
@@ -38,8 +39,10 @@ export class LoginComponent {
   onLogin(): void {
     if (this.loginForm.valid) {
       const credenciales = this.loginForm.value;
-      console.log('Enviando login:', credenciales);
-      // Aquí harás la petición HTTP al backend
+      this.auth.login(credenciales).subscribe({
+        next: () => console.log('Usuario autenticado'),
+        error: err => console.error('Error de login', err)
+      });
     }
   }
 }

--- a/marketplace-frontend/src/app/features/auth/register/register.component.ts
+++ b/marketplace-frontend/src/app/features/auth/register/register.component.ts
@@ -2,9 +2,10 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-register',
+  standalone: true,
   imports: [],
   templateUrl: './register.component.html',
-  styleUrl: './register.component.scss'
+  styleUrls: ['./register.component.scss']
 })
 export class RegisterComponent {
 

--- a/marketplace-frontend/src/environments/environment.development.ts
+++ b/marketplace-frontend/src/environments/environment.development.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: 'http://localhost:3000'
+};

--- a/marketplace-frontend/src/environments/environment.ts
+++ b/marketplace-frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: 'http://localhost:3000'
+};


### PR DESCRIPTION
## Summary
- fix usage of `styleUrls` and enable standalone components
- create environment files with backend URL
- add API and authentication services
- register HTTP interceptors
- connect the login form with the backend
- add unit tests for the new services
- document environment config and testing in the README

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8242a808832292b2a490f27d3dcc